### PR TITLE
docs: fix log cdi build time config keys

### DIFF
--- a/extensions/log/cdi/README.md
+++ b/extensions/log/cdi/README.md
@@ -17,9 +17,9 @@ Build time configuration.
 # Enable or disable autodiscovery
 tkit.log.cdi.auto-discovery.enabled=false
 # Binding includes packages. (list)
-tkit.log.cdi.packages=org.tkit
+tkit.log.cdi.auto-discovery.packages=org.tkit
 # Specify ignore pattern. (optional)
-tkit.log.cdi.ignore.pattern=
+tkit.log.cdi.auto-discovery.ignore.pattern=
 ```
 
 Runtime configuration.


### PR DESCRIPTION
https://github.com/1000kit/tkit-quarkus/blob/e9bab19ecc2b37c63e153f39b79baa6fe67b3ac9/extensions/log/cdi/README.md?plain=1#L19-L22

should be

```
 # Binding includes packages. (list) 
 tkit.log.cdi.auto-discovery.packages=org.tkit 
 # Specify ignore pattern. (optional) 
 tkit.log.cdi.auto-discovery.ignore.pattern= 
```

due to

https://github.com/1000kit/tkit-quarkus/blob/e9bab19ecc2b37c63e153f39b79baa6fe67b3ac9/extensions/log/cdi/deployment/src/main/java/org/tkit/quarkus/log/cdi/LogBuildTimeConfig.java#L14-L38