### PR TITLE
fix: jakarta.persistence.load-graph -> jakarta.persistence.loadgraph

### DIFF
--- a/extensions/jpa/runtime/src/main/java/org/tkit/quarkus/jpa/daos/AbstractDAO.java
+++ b/extensions/jpa/runtime/src/main/java/org/tkit/quarkus/jpa/daos/AbstractDAO.java
@@ -32,13 +32,13 @@ public abstract class AbstractDAO<T> extends EntityService<T> {
     private static final Logger log = LoggerFactory.getLogger(AbstractDAO.class);
 
     /**
-     * The property hint is jakarta.persistence.load-graph.
+     * The property hint is jakarta.persistence.loadgraph.
      * <p>
      * This hint will treat all the specified attributes in the Entity Graph as
      * FetchType.EAGER. Attributes that are not specified are treated as
      * FetchType.LAZY.
      */
-    protected static final String HINT_LOAD_GRAPH = "jakarta.persistence.load-graph";
+    protected static final String HINT_LOAD_GRAPH = "jakarta.persistence.loadgraph";
 
     /**
      * The entity manager.


### PR DESCRIPTION
Jpa hint "jakarta.persistence.load-graph" is incorrect and thus ignored by JPA. As a result entities in graph are not loaded which can lead to other problems (agroal pool: "Enlisted connection used without active transaction")
Jpa produce logs "HHH90003003: Ignoring unrecognized query hint [jakarta.persistence.load-graph]"