### PR TITLE
fix(datasource): enhance DataSourcePool caching with JDBC URL for test

### DIFF
--- a/extensions/test-db-import/src/main/java/org/tkit/quarkus/test/dbunit/DataSourcePool.java
+++ b/extensions/test-db-import/src/main/java/org/tkit/quarkus/test/dbunit/DataSourcePool.java
@@ -26,15 +26,34 @@ public class DataSourcePool {
     }
 
     public static Connection getConnection(String name) throws SQLException {
-        return CACHE.computeIfAbsent(name, DataSourcePool::create).getConnection();
+        String cacheKey = cacheKey(name);
+        return CACHE.computeIfAbsent(cacheKey, k -> create(name)).getConnection();
+    }
+
+    /**
+     * Builds a cache key that includes the current JDBC URL so that a stale pooled DataSource is
+     * never reused after the underlying database changed - e.g. when a Quarkus app reload
+     * (TestProfile switch) re-provisions the DevServices database on a new URL. A changed URL yields
+     * a new key and therefore a fresh DataSource.
+     */
+    private static String cacheKey(String name) {
+        String url = ConfigProvider.getConfig()
+                .getOptionalValue(prefix(name) + ConfigurationConst.JDBC_URL, String.class)
+                .orElse(name);
+        return name + "|" + url;
+    }
+
+    private static String prefix(String name) {
+        String prefix = ConfigurationConst.DATASOURCE_PREFIX;
+        if (name != null && !name.equals(ConfigurationConst.DEFAULT_DATASOURCE_VALUE)) {
+            prefix = prefix + name + ".";
+        }
+        return prefix;
     }
 
     private static DataSource create(String name) {
         try {
-            String prefix = ConfigurationConst.DATASOURCE_PREFIX;
-            if (name != null && !name.equals(ConfigurationConst.DEFAULT_DATASOURCE_VALUE)) {
-                prefix = prefix + name + ".";
-            }
+            String prefix = prefix(name);
             Config config = ConfigProvider.getConfig();
             String username = config.getValue(prefix + ConfigurationConst.USERNAME, String.class);
             String password = config.getValue(prefix + ConfigurationConst.PASSWORD, String.class);

--- a/it/jpa/src/test/java/org/tkit/quarkus/it/jpa/DbImportReloadProfile.java
+++ b/it/jpa/src/test/java/org/tkit/quarkus/it/jpa/DbImportReloadProfile.java
@@ -1,0 +1,23 @@
+package org.tkit.quarkus.it.jpa;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Dummy-config test profile whose only purpose is to differ from the default profile.
+ *
+ * <p>
+ * Applied to {@link UserRestControllerDbImportReloadIT}, it makes that class use a different
+ * Quarkus configuration than the default-profile {@code UserRestControllerIT}. In a
+ * {@code @QuarkusIntegrationTest} run (single shared failsafe JVM) that difference forces Quarkus to
+ * reload the application onto a freshly provisioned DevServices database between the two classes -
+ * which is exactly what exercises the {@code DataSourcePool} JDBC-URL-aware cache key.
+ */
+public class DbImportReloadProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("tkit.it.db-import-reload", "dummy");
+    }
+}

--- a/it/jpa/src/test/java/org/tkit/quarkus/it/jpa/UserRestControllerDbImportReloadIT.java
+++ b/it/jpa/src/test/java/org/tkit/quarkus/it/jpa/UserRestControllerDbImportReloadIT.java
@@ -1,0 +1,28 @@
+package org.tkit.quarkus.it.jpa;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Integration-test regression guard for the {@code test-db-import} {@code DataSourcePool} stale-cache
+ * bug.
+ *
+ * <p>
+ * This class reuses {@link UserRestControllerTest}'s {@code @WithDBData} import + {@code GET {id}}
+ * verification, but runs under {@link DbImportReloadProfile}. Together with the default-profile
+ * {@code UserRestControllerIT}, the two classes share one failsafe JVM but use different profiles, so
+ * Quarkus reloads the app onto a new DevServices database between them. The static
+ * {@code DataSourcePool} cache survives that reload.
+ *
+ * <ul>
+ * <li>Before the fix (cache keyed by datasource name only) the second class to run reuses the
+ * DataSource cached by the first - now pointing at a stopped database - and fails with
+ * {@code PSQLException: An I/O error occurred while sending to the backend}.</li>
+ * <li>With the fix (cache key includes the JDBC URL) a fresh DataSource is created for the new
+ * database and the import + read-back succeed.</li>
+ * </ul>
+ */
+@QuarkusIntegrationTest
+@TestProfile(DbImportReloadProfile.class)
+class UserRestControllerDbImportReloadIT extends UserRestControllerTest {
+}


### PR DESCRIPTION
fix(test-db-import): include JDBC URL in DataSourcePool cache key to avoid stale DataSource after app reload (#432)